### PR TITLE
Upgraded library versions

### DIFF
--- a/project/MicroServiceBuild.scala
+++ b/project/MicroServiceBuild.scala
@@ -11,14 +11,14 @@ private object AppDependencies {
   import play.sbt.PlayImport._
   import play.core.PlayVersion
 
-  private val microserviceBootstrapVersion = "6.17.0"
+  private val microserviceBootstrapVersion = "6.18.0"
   private val domainVersion = "5.1.0"
   private val hmrcTestVersion = "2.4.0"
   private val scalaTestVersion = "2.2.6"
   private val pegdownVersion = "1.6.0"
   private val playUiVersion = "7.4.0"
 
-  private val playReactivemongoVersion = "6.1.0"
+  private val playReactivemongoVersion = "6.2.0"
   private val scalatestPlusPlayVersion = "1.5.1"
 
   val compile = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,17 +1,10 @@
 resolvers += Resolver.url("hmrc-sbt-plugin-releases", url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
-
-val hmrcRepoHost = java.lang.System.getProperty("hmrc.repo.host", "https://nexus-preview.tax.service.gov.uk")
+resolvers += Resolver.bintrayRepo("hmrc", "releases")
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
-
-resolvers ++= Seq("hmrc-snapshots" at hmrcRepoHost + "/content/repositories/hmrc-snapshots",
-  "hmrc-releases" at hmrcRepoHost + "/content/repositories/hmrc-releases",
-  "typesafe-releases" at hmrcRepoHost + "/content/repositories/typesafe-releases",
-  Resolver.url("hmrc-sbt-plugin-releases",
-    url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(Resolver.ivyStylePatterns))
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.8.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "0.9.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "0.10.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "1.0.0")
 


### PR DESCRIPTION
This is to comply with out-of-date library versions in the Tax Catalogue.

This commit also removes library resolvers which have flagged up an issue with the leak detection software.