### PR TITLE
AMLS-4738 | Replaced deprecated methods with DI

### DIFF
--- a/app/config/AmlsConfig.scala
+++ b/app/config/AmlsConfig.scala
@@ -16,15 +16,15 @@
 
 package config
 
-import play.api.{Configuration, Play}
+import javax.inject.Inject
 import play.api.Mode.Mode
+import play.api.{Application, Configuration}
 import uk.gov.hmrc.play.config.ServicesConfig
 
-object AmlsConfig extends ServicesConfig {
+class AmlsConfig @Inject()(app: Application) extends ServicesConfig {
 
-  override protected def mode: Mode = Play.current.mode
-
-  override protected def runModeConfiguration: Configuration = Play.current.configuration
+  override protected def mode: Mode = app.mode
+  override protected def runModeConfiguration: Configuration = app.configuration
 
   private def loadConfig(key: String) =
     getConfString(key, throw new Exception(s"Config missing key: $key"))
@@ -36,6 +36,4 @@ object AmlsConfig extends ServicesConfig {
   lazy val emailUrl = baseUrl("email")
   lazy val currentTemplatePackageVersion = loadConfig("current-template-package-version")
   lazy val defaultTemplatePackageVersion = loadConfig("default-template-package-version")
-
-
 }

--- a/app/connectors/ViewNotificationConnector.scala
+++ b/app/connectors/ViewNotificationConnector.scala
@@ -18,7 +18,9 @@ package connectors
 
 
 import audit.ViewNotificationEvent
+import config.{AmlsConfig, MicroserviceAuditConnector, WSHttp}
 import exceptions.HttpStatusException
+import javax.inject.Inject
 import metrics.API11
 import models.des.NotificationResponse
 import play.api.Logger
@@ -29,10 +31,14 @@ import uk.gov.hmrc.http.HttpResponse
 import scala.concurrent.{ExecutionContext, Future}
 
 
-trait ViewNotificationConnector extends DESConnector {
+class ViewNotificationConnector @Inject()(
+  amlsConfig: AmlsConfig,
+  wsHttp: WSHttp,
+  auditConnector: MicroserviceAuditConnector
+) extends DESConnector(amlsConfig, wsHttp, auditConnector) {
 
   def getNotification(amlsRegistrationNumber: String, contactNumber: String)
-                     (implicit ec: ExecutionContext, wr: Writes[NotificationResponse]): Future[NotificationResponse] = {
+    (implicit ec: ExecutionContext, wr: Writes[NotificationResponse]): Future[NotificationResponse] = {
 
     val prefix = "[DESConnector][getNotification]"
     val bodyParser = JsonParsed[NotificationResponse]

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,7 +1,7 @@
 # microservice specific routes
 
-GET         /:accountType/:ref/safeId/:safeId                                 controllers.NotificationController.fetchNotificationsBySafeId(accountType: String, ref: String, safeId: String)
-GET         /:accountType/:ref/:amlsRegistrationNumber/:notificationId        controllers.ViewNotificationController.viewNotification(accountType:String, ref:String, amlsRegistrationNumber:String, notificationId:String)
-GET         /:accountType/:ref/:amlsRegistrationNumber                        controllers.NotificationController.fetchNotifications(accountType:String, ref:String, amlsRegistrationNumber:String)
+GET         /:accountType/:ref/safeId/:safeId                                 @controllers.NotificationController.fetchNotificationsBySafeId(accountType: String, ref: String, safeId: String)
+GET         /:accountType/:ref/:amlsRegistrationNumber/:notificationId        @controllers.ViewNotificationController.viewNotification(accountType:String, ref:String, amlsRegistrationNumber:String, notificationId:String)
+GET         /:accountType/:ref/:amlsRegistrationNumber                        @controllers.NotificationController.fetchNotifications(accountType:String, ref:String, amlsRegistrationNumber:String)
 
-POST        /:amlsRegistrationNumber                                          controllers.NotificationController.saveNotification(amlsRegistrationNumber:String)
+POST        /:amlsRegistrationNumber                                          @controllers.NotificationController.saveNotification(amlsRegistrationNumber:String)

--- a/release_notes/AMLS-4738.txt
+++ b/release_notes/AMLS-4738.txt
@@ -1,0 +1,1 @@
+ + [AMLS-4738] - | Updated DI in Notifications

--- a/test/connectors/EmailConnectorSpec.scala
+++ b/test/connectors/EmailConnectorSpec.scala
@@ -16,6 +16,8 @@
 
 package connectors
 
+import config.{AmlsConfig, WSHttp}
+import javax.inject.Inject
 import org.mockito.ArgumentCaptor
 import org.mockito.Matchers._
 import org.mockito.Mockito._
@@ -25,12 +27,18 @@ import org.scalatest.mock.MockitoSugar
 import org.scalatestplus.play.{OneServerPerSuite, PlaySpec}
 import play.api.Mode.Mode
 import play.api.test.Helpers._
-import play.api.{Configuration, Play}
+import play.api.{Application, Configuration}
 import uk.gov.hmrc.http.{CorePost, HeaderCarrier, HttpResponse}
 
 import scala.concurrent.Future
 
-class EmailConnectorSpec extends PlaySpec with MockitoSugar with ScalaFutures with IntegrationPatience with OneServerPerSuite with BeforeAndAfterAll {
+class EmailConnectorSpec @Inject()(app: Application, amlsConfig: AmlsConfig, wsHttp: WSHttp)
+  extends PlaySpec
+  with MockitoSugar
+  with ScalaFutures
+  with IntegrationPatience
+  with OneServerPerSuite
+  with BeforeAndAfterAll {
 
   trait Fixture {
 
@@ -39,13 +47,13 @@ class EmailConnectorSpec extends PlaySpec with MockitoSugar with ScalaFutures wi
     val mockHttp = mock[CorePost]
     val sendTo = "e@mail.com"
 
-    object TestEmailConnector extends EmailConnector {
+    object TestEmailConnector extends EmailConnector(app, amlsConfig, wsHttp) {
       override def httpPost = mockHttp
       override def url = "test-email-url"
 
-      override protected def mode: Mode = Play.current.mode
+      override protected def mode: Mode = app.mode
 
-      override protected def runModeConfiguration: Configuration = Play.current.configuration
+      override protected def runModeConfiguration: Configuration = app.configuration
     }
 
   }

--- a/test/connectors/ViewNotificationConnectorSpec.scala
+++ b/test/connectors/ViewNotificationConnectorSpec.scala
@@ -18,7 +18,9 @@ package connectors
 
 import audit.MockAudit
 import com.codahale.metrics.Timer
+import config.{AmlsConfig, MicroserviceAuditConnector, WSHttp}
 import exceptions.HttpStatusException
+import javax.inject.Inject
 import metrics.{API11, Metrics}
 import org.joda.time.{DateTimeUtils, LocalDateTime}
 import org.mockito.Matchers.{eq => eqTo, _}
@@ -35,11 +37,14 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import uk.gov.hmrc.http._
 
-class ViewNotificationConnectorSpec
-  extends PlaySpec
-    with MockitoSugar
-    with ScalaFutures
-    with IntegrationPatience with OneServerPerSuite with BeforeAndAfterAll {
+class ViewNotificationConnectorSpec @Inject()(
+  amlsConfig: AmlsConfig,
+  wsHttp: WSHttp,
+  auditConnector:MicroserviceAuditConnector
+) extends PlaySpec
+  with MockitoSugar
+  with ScalaFutures
+  with IntegrationPatience with OneServerPerSuite with BeforeAndAfterAll {
 
   override def beforeAll {
     DateTimeUtils.setCurrentMillisFixed(1000)
@@ -51,11 +56,11 @@ class ViewNotificationConnectorSpec
 
   trait Fixture {
 
-    object testConnector extends ViewNotificationConnector {
-      override private[connectors] val baseUrl: String = "baseUrl"
-      override private[connectors] val token: String = "token"
-      override private[connectors] val env: String = "ist0"
-      override private[connectors] val http = mock[CoreGet with CorePost]
+    object testConnector extends ViewNotificationConnector(amlsConfig, wsHttp, auditConnector) {
+      lazy override private[connectors] val baseUrl: String = "baseUrl"
+      lazy override private[connectors] val token: String = "token"
+      lazy override private[connectors] val env: String = "ist0"
+      lazy override private[connectors] val http = mock[WSHttp]
       override private[connectors] val metrics: Metrics = mock[Metrics]
       override private[connectors] val audit = MockAudit
       override private[connectors] val fullUrl: String = s"$baseUrl/$requestUrl"

--- a/test/controllers/ViewNotificationControllerSpec.scala
+++ b/test/controllers/ViewNotificationControllerSpec.scala
@@ -17,40 +17,42 @@
 package controllers
 
 
-import connectors.ViewNotificationConnector
+import config.MicroserviceAuditConnector
+import connectors.{DESConnector, ViewNotificationConnector}
 import exceptions.HttpStatusException
+import javax.inject.Inject
 import models._
 import models.fe.NotificationDetails
 import org.joda.time.{DateTime, DateTimeZone}
 import org.mockito.ArgumentCaptor
+import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.Mockito._
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalatestplus.play.{OneAppPerSuite, PlaySpec}
 import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import org.mockito.Matchers.{eq => eqTo, _}
-import org.mockito.Mockito._
-import org.scalatest.concurrent.ScalaFutures
-import repositories.NotificationRepository
-import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}
+import repositories.NotificationMongoRepository
+import uk.gov.hmrc.play.audit.http.connector.AuditResult
 import uk.gov.hmrc.play.audit.model.ExtendedDataEvent
-
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits.global
 import utils.DataGen._
 
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
-class ViewNotificationControllerSpec extends PlaySpec with GeneratorDrivenPropertyChecks
-  with ScalaFutures
-  with MockitoSugar
-  with OneAppPerSuite {
+class ViewNotificationControllerSpec @Inject()(
+  connector: DESConnector,
+  notificationConnector: ViewNotificationConnector,
+  msAuditConnector: MicroserviceAuditConnector
+) extends PlaySpec with GeneratorDrivenPropertyChecks with ScalaFutures  with MockitoSugar with OneAppPerSuite {
 
   trait Fixture {
-    val TestController = new ViewNotificationController {
-      override val connector = mock[ViewNotificationConnector]
-      override private[controllers] val audit = mock[AuditConnector]
-      override private[controllers] val notificationRepository = mock[NotificationRepository]
+    val TestController = new ViewNotificationController(connector, notificationConnector, msAuditConnector) {
+      val connector = mock[ViewNotificationConnector]
+      override private[controllers] val audit = mock[MicroserviceAuditConnector]
+      override private[controllers] val notificationRepository = mock[NotificationMongoRepository]
     }
   }
 


### PR DESCRIPTION
Replaced calls to Play.current with DI, along with further affected files. Remaining deprecated methods are in AmlsGlobal, which will be removed as part of the upgrade to Play 2.6.

## Related / Dependant PRs?

## How Has This Been Tested?

Unit and regression tests.

## Checklist

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [X] Build passing.
- [X] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [X] Appropriate labels added.
- [X] RELEASE NOTES ADDED.