### PR TITLE
Remove deprecated hmrctest lib

### DIFF
--- a/project/MicroServiceBuild.scala
+++ b/project/MicroServiceBuild.scala
@@ -13,7 +13,6 @@ private object AppDependencies {
 
   private val microserviceBootstrapVersion = "10.6.0"
   private val domainVersion = "5.2.0"
-  private val hmrcTestVersion = "2.4.0"
   private val scalaTestVersion = "2.2.6"
   private val pegdownVersion = "1.6.0"
   private val playUiVersion = "7.4.0"
@@ -36,7 +35,6 @@ private object AppDependencies {
   object Test {
     def apply() = new TestDependencies {
       override lazy val test = Seq(
-        "uk.gov.hmrc" %% "hmrctest" % hmrcTestVersion % scope,
         "org.scalatest" %% "scalatest" % scalaTestVersion % scope,
         "org.scalatestplus.play" %% "scalatestplus-play" % scalatestPlusPlayVersion,
         "org.pegdown" % "pegdown" % pegdownVersion % scope,
@@ -53,7 +51,6 @@ private object AppDependencies {
       override lazy val scope: String = "it"
 
       override lazy val test = Seq(
-        "uk.gov.hmrc" %% "hmrctest" % hmrcTestVersion % scope,
         "org.scalatest" %% "scalatest" % scalaTestVersion % scope,
         "org.scalatestplus.play" %% "scalatestplus-play" % scalatestPlusPlayVersion,
         "org.pegdown" % "pegdown" % pegdownVersion % scope,


### PR DESCRIPTION
Remove deprecated hmrctest lib

<img width="596" alt="Screenshot 2019-06-05 at 10 14 47" src="https://user-images.githubusercontent.com/40767309/58960496-375e7d80-879f-11e9-9d21-09bf8d4b5ff2.png">


## Related / Dependant PRs?

<!--- List any related issues here -->N/A

## How Has This Been Tested?

Unit + Acceptance 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [ ] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [x] Appropriate labels added.
- [ ] RELEASE NOTES ADDED.
