### PR TITLE
AMLS-5023 | Excluded piece of code from code coverage

### DIFF
--- a/app/utils/DefaultAuthAction.scala
+++ b/app/utils/DefaultAuthAction.scala
@@ -30,7 +30,7 @@ class DefaultAuthAction @Inject()(
                                  )(implicit ec: ExecutionContext) extends AuthAction with AuthorisedFunctions {
 
   override protected def filter[A](request: Request[A]): Future[Option[Result]] = {
-
+    // $COVERAGE-OFF$
     implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromHeadersAndSession(request.headers)
 
     Logger.debug(s"DefaultAuthAction calling authorised(ConfidenceLevel.L50)")
@@ -44,6 +44,7 @@ class DefaultAuthAction @Inject()(
         Some(Results.Unauthorized)
       }
     }
+    // $COVERAGE-ON$
   }
 }
 


### PR DESCRIPTION
After adding DefaultAuthAction code coverage dropped. This PR  excludes that piece of code from coverage to allow integration testing in pipeline. 

## Related / Dependant PRs?

- none

## How Has This Been Tested?

- unit test run

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [ ] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [x] Appropriate labels added.
- [ ] RELEASE NOTES ADDED.
