### PR TITLE
Revert Notifications Controller to using out of the box play auth as auth is manually disabled for this controller - fixes Assyst 1961565

### DIFF
--- a/app/controllers/NotificationController.scala
+++ b/app/controllers/NotificationController.scala
@@ -26,18 +26,17 @@ import org.joda.time.{DateTime, DateTimeZone}
 import play.api.Logger
 import play.api.data.validation.ValidationError
 import play.api.libs.json._
+import play.api.mvc.Action
 import repositories.NotificationRepository
 import uk.gov.hmrc.play.microservice.controller.BaseController
-import utils.AuthAction
-
 import scala.concurrent.ExecutionContext.Implicits.global
+
 import scala.concurrent.Future
 
 class NotificationController @Inject()(
   emailConnector: EmailConnector,
   amlsConfig: AmlsConfig,
-  msAuditConnector: MicroserviceAuditConnector,
-  authAction: AuthAction
+  msAuditConnector: MicroserviceAuditConnector
 ) extends BaseController {
 
   val amlsRegNoRegex = "^X[A-Z]ML00000[0-9]{6}$".r
@@ -65,7 +64,7 @@ class NotificationController @Inject()(
 
   //noinspection ScalaStyle
   def saveNotification(amlsRegistrationNumber: String) =
-    authAction.async(parse.json) {
+    Action.async(parse.json) {
       implicit request =>
         Logger.debug(s"$prefix [saveNotification] - amlsRegNo: $amlsRegistrationNumber, body: ${request.body.toString}")
         amlsRegNoRegex.findFirstIn(amlsRegistrationNumber) match {
@@ -130,7 +129,7 @@ class NotificationController @Inject()(
     }
 
   def fetchNotifications(accountType: String, ref: String, amlsRegistrationNumber: String) =
-    authAction.async {
+    Action.async {
       implicit request =>
         Logger.debug(s"$prefix [fetchNotifications] - amlsRegNo: $amlsRegistrationNumber")
         amlsRegNoRegex.findFirstIn(amlsRegistrationNumber) match {
@@ -153,7 +152,7 @@ class NotificationController @Inject()(
     }
 
   def fetchNotificationsBySafeId(accountType: String, ref: String, safeId: String) =
-    authAction.async {
+    Action.async {
       implicit request =>
         Logger.debug(s"$prefix [fetchNotificationsBySafeId] - safeId: $safeId")
         safeIdRegex.findFirstIn(safeId) match {

--- a/release_notes/AMLS-5225.txt
+++ b/release_notes/AMLS-5225.txt
@@ -1,0 +1,1 @@
+ + [AMLS-5225] - 'Revert Notifications Controller to using out of the box play auth as auth is manually disabled for this controller - fixes Assyst 1961565'

--- a/test/controllers/NotificationControllerSpec.scala
+++ b/test/controllers/NotificationControllerSpec.scala
@@ -51,8 +51,7 @@ class NotificationControllerSpec extends PlaySpec
   object TestNotificationController extends NotificationController(
     app.injector.instanceOf(classOf[EmailConnector]),
     amlsConfig,
-    app.injector.instanceOf(classOf[MicroserviceAuditConnector]),
-    authAction
+    app.injector.instanceOf(classOf[MicroserviceAuditConnector])
   ) {
     override private[controllers] val notificationRepository = mock[NotificationMongoRepository]
     private[controllers] val emailConnector = mock[EmailConnector]


### PR DESCRIPTION
Revert Notifications Controller to using out of the box play auth as auth is manually disabled for this controller - fixes Assyst 1961565

## Related / Dependant PRs?

N/A

## How Has This Been Tested?

Unit + Regression

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [x] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [x] Appropriate labels added.
- [x] RELEASE NOTES ADDED.
